### PR TITLE
fix: error when attempting to append to processing json

### DIFF
--- a/src/aind_metadata_manager/metadata_manager.py
+++ b/src/aind_metadata_manager/metadata_manager.py
@@ -434,6 +434,37 @@ class MetadataManager:
 
         return processings
 
+    def _collect_pipelines(
+        self, existing_processings: List[Processing]
+    ) -> List[Code]:
+        """Collect pipelines from existing processing.json files (carried
+        forward so data processes referencing them via pipeline_name still
+        validate) plus the current settings pipeline, deduped by name.
+        """
+        pipelines: List[Code] = []
+        seen_pipeline_names: set = set()
+
+        def _register(pipeline: Code) -> None:
+            """Cache a pipeline once, keyed by name."""
+            if pipeline.name in seen_pipeline_names:
+                return
+            seen_pipeline_names.add(pipeline.name)
+            pipelines.append(pipeline)
+
+        for processing in existing_processings:
+            for pipeline in processing.pipelines or []:
+                _register(pipeline)
+
+        _register(
+            Code(
+                url=self.settings.pipeline_url,
+                version=self.settings.pipeline_version,
+                name=self.settings.pipeline_name,
+            )
+        )
+
+        return pipelines
+
     def create_processing_metadata(self) -> Processing:
         """
         Create Processing object with collected data processes.
@@ -450,8 +481,7 @@ class MetadataManager:
         data_processes: List[DataProcess] = []
         dependency_graph: dict = {}
         seen_names: set = set()
-        pipelines: List[Code] = []
-        seen_pipeline_names: set = set()
+        pipelines = self._collect_pipelines(existing_processings)
 
         def _register(process: DataProcess, deps: List[str]) -> None:
             """Registers DataPorcess attributes if not already cached"""
@@ -464,28 +494,6 @@ class MetadataManager:
             seen_names.add(name)
             data_processes.append(process)
             dependency_graph[name] = deps
-
-        def _register_pipeline(pipeline: Code) -> None:
-            """Register a pipeline once, keyed by name, so pipeline_name
-            references from merged data processes remain resolvable."""
-            if pipeline.name in seen_pipeline_names:
-                return
-            seen_pipeline_names.add(pipeline.name)
-            pipelines.append(pipeline)
-
-        # Carry forward pipelines from existing processing.json files so that
-        # data processes referencing them (via pipeline_name) still validate.
-        for processing in existing_processings:
-            for pipeline in processing.pipelines or []:
-                _register_pipeline(pipeline)
-
-        _register_pipeline(
-            Code(
-                url=self.settings.pipeline_url,
-                version=self.settings.pipeline_version,
-                name=self.settings.pipeline_name,
-            )
-        )
 
         for processing in existing_processings:
             existing_graph = processing.dependency_graph or {}

--- a/src/aind_metadata_manager/metadata_manager.py
+++ b/src/aind_metadata_manager/metadata_manager.py
@@ -450,6 +450,8 @@ class MetadataManager:
         data_processes: List[DataProcess] = []
         dependency_graph: dict = {}
         seen_names: set = set()
+        pipelines: List[Code] = []
+        seen_pipeline_names: set = set()
 
         def _register(process: DataProcess, deps: List[str]) -> None:
             """Registers DataPorcess attributes if not already cached"""
@@ -463,6 +465,28 @@ class MetadataManager:
             data_processes.append(process)
             dependency_graph[name] = deps
 
+        def _register_pipeline(pipeline: Code) -> None:
+            """Register a pipeline once, keyed by name, so pipeline_name
+            references from merged data processes remain resolvable."""
+            if pipeline.name in seen_pipeline_names:
+                return
+            seen_pipeline_names.add(pipeline.name)
+            pipelines.append(pipeline)
+
+        # Carry forward pipelines from existing processing.json files so that
+        # data processes referencing them (via pipeline_name) still validate.
+        for processing in existing_processings:
+            for pipeline in processing.pipelines or []:
+                _register_pipeline(pipeline)
+
+        _register_pipeline(
+            Code(
+                url=self.settings.pipeline_url,
+                version=self.settings.pipeline_version,
+                name=self.settings.pipeline_name,
+            )
+        )
+
         for processing in existing_processings:
             existing_graph = processing.dependency_graph or {}
             for process in processing.data_processes:
@@ -474,13 +498,7 @@ class MetadataManager:
 
         processing = Processing(
             data_processes=data_processes,
-            pipelines=[
-                Code(
-                    url=self.settings.pipeline_url,
-                    version=self.settings.pipeline_version,
-                    name=self.settings.pipeline_name,
-                )
-            ],
+            pipelines=pipelines,
             dependency_graph=dependency_graph,
         )
 

--- a/tests/test_metadata_manager.py
+++ b/tests/test_metadata_manager.py
@@ -622,6 +622,51 @@ class TestProcessingAggregation(unittest.TestCase):
                 self.assertEqual(processing.dependency_graph["A"], [])
                 self.assertEqual(processing.dependency_graph["Standalone"], [])
 
+    def test_existing_pipelines_carried_forward(self):
+        """Regression for #51: pipelines from an existing processing.json are
+        preserved so data processes referencing them via pipeline_name still
+        validate, rather than raising 'Pipeline name ... not found'.
+        """
+        with mock.patch("sys.argv", [""]):
+            with tempfile.TemporaryDirectory() as tempdir:
+                input_dir = Path(tempdir) / "input"
+                output_dir = Path(tempdir) / "output"
+                input_dir.mkdir()
+                output_dir.mkdir()
+
+                referencing_process = _make_data_process_dict("A")
+                referencing_process["pipeline_name"] = "transform_and_upload_v2"
+                existing = {
+                    "data_processes": [referencing_process],
+                    "dependency_graph": {"A": []},
+                    "pipelines": [
+                        {
+                            "url": "http://example.com/pipeline",
+                            "version": "2.0",
+                            "name": "transform_and_upload_v2",
+                        }
+                    ],
+                }
+                (input_dir / "prior_processing.json").write_text(
+                    json.dumps(existing)
+                )
+                (input_dir / "step_data_process.json").write_text(
+                    json.dumps(_make_data_process_dict("Standalone"))
+                )
+
+                settings = DummySettings(
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    pipeline_name="current_pipeline",
+                )
+                manager = MetadataManager(settings)
+                processing = manager.create_processing_metadata()
+
+                pipeline_names = {p.name for p in processing.pipelines}
+                # Existing pipeline carried forward + current one added.
+                self.assertIn("transform_and_upload_v2", pipeline_names)
+                self.assertIn("current_pipeline", pipeline_names)
+
     def test_duplicate_process_names_raise(self):
         """Two sources contributing a DataProcess with the same name
         raise ValueError.

--- a/tests/test_metadata_manager.py
+++ b/tests/test_metadata_manager.py
@@ -635,7 +635,9 @@ class TestProcessingAggregation(unittest.TestCase):
                 output_dir.mkdir()
 
                 referencing_process = _make_data_process_dict("A")
-                referencing_process["pipeline_name"] = "transform_and_upload_v2"
+                referencing_process["pipeline_name"] = (
+                    "transform_and_upload_v2"
+                )
                 existing = {
                     "data_processes": [referencing_process],
                     "dependency_graph": {"A": []},
@@ -666,6 +668,45 @@ class TestProcessingAggregation(unittest.TestCase):
                 # Existing pipeline carried forward + current one added.
                 self.assertIn("transform_and_upload_v2", pipeline_names)
                 self.assertIn("current_pipeline", pipeline_names)
+
+    def test_duplicate_pipeline_names_deduped(self):
+        """A pipeline name appearing in an existing file and matching the
+        current settings pipeline is only listed once.
+        """
+        with mock.patch("sys.argv", [""]):
+            with tempfile.TemporaryDirectory() as tempdir:
+                input_dir = Path(tempdir) / "input"
+                output_dir = Path(tempdir) / "output"
+                input_dir.mkdir()
+                output_dir.mkdir()
+
+                referencing_process = _make_data_process_dict("A")
+                referencing_process["pipeline_name"] = "shared_pipeline"
+                existing = {
+                    "data_processes": [referencing_process],
+                    "dependency_graph": {"A": []},
+                    "pipelines": [
+                        {
+                            "url": "http://example.com/pipeline",
+                            "version": "2.0",
+                            "name": "shared_pipeline",
+                        }
+                    ],
+                }
+                (input_dir / "prior_processing.json").write_text(
+                    json.dumps(existing)
+                )
+
+                settings = DummySettings(
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    pipeline_name="shared_pipeline",
+                )
+                manager = MetadataManager(settings)
+                processing = manager.create_processing_metadata()
+
+                pipeline_names = [p.name for p in processing.pipelines]
+                self.assertEqual(pipeline_names, ["shared_pipeline"])
 
     def test_duplicate_process_names_raise(self):
         """Two sources contributing a DataProcess with the same name


### PR DESCRIPTION
Hotfix for #51. If a raw asset already has a processing.json, then existing data_processes were merged, but the pipelines list was being rebuilt from scratch. The merged data processes still carried the pipeline_name from the original asset's pipeline list. `aind-data-schema` validates that every `data_process.pipeline_name` exists in `pipelines`, so I think that's what triggered #51.

This carries forward the pipeline name. A sample processing json shows the merged json running below. I did not validate it entirely but it merged and ran successfully Not sure if this is the best way, but it's currently blocking from releasing the dynamic foraging pipeline.

```
{
   "object_type": "Processing",
   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
   "schema_version": "2.3.0",
   "data_processes": [
      {
         "object_type": "Data process",
         "process_type": "Other",
         "name": "Other",
         "stage": "Processing",
         "code": {
            "object_type": "Code",
            "url": "",
            "name": null,
            "version": "",
            "commit_hash": null,
            "container": null,
            "run_script": null,
            "language": null,
            "language_version": null,
            "input_data": null,
            "parameters": {
               "input_source": "//allen/aind/stage/vr-foraging/data/860898/860898_2026-07-09T193353Z/behavior"
            },
            "core_dependency": null
         },
         "experimenters": [
            "AIND Scientific Computing"
         ],
         "pipeline_name": "transform_and_upload_v2",
         "start_date_time": "2026-07-10T01:15:29Z",
         "end_date_time": "2026-07-10T01:15:30Z",
         "output_path": null,
         "output_parameters": null,
         "notes": "Data was copied",
         "resources": null
      },
      {
         "object_type": "Data process",
         "process_type": "Compression",
         "name": "Compression",
         "stage": "Processing",
         "code": {
            "object_type": "Code",
            "url": "ghcr.io/allenneuraldynamics/aind-behavior-video-transformation",
            "name": null,
            "version": "0.2.1",
            "commit_hash": null,
            "container": null,
            "run_script": null,
            "language": null,
            "language_version": null,
            "input_data": null,
            "parameters": {
               "input_source": "//allen/aind/stage/vr-foraging/data/860898/860898_2026-07-09T193353Z/behavior-videos",
               "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/860898_2026-07-09_19-33-53_aa0568f31b/behavior-videos"
            },
            "core_dependency": null
         },
         "experimenters": [
            "AIND Scientific Computing"
         ],
         "pipeline_name": "transform_and_upload_v2",
         "start_date_time": "2026-07-10T01:15:29Z",
         "end_date_time": "2026-07-10T11:36:16Z",
         "output_path": null,
         "output_parameters": null,
         "notes": null,
         "resources": null
      }
   ],
   "pipelines": [
      {
         "object_type": "Code",
         "url": "https://github.com/AllenNeuralDynamics/aind-airflow-dags",
         "name": "transform_and_upload_v2",
         "version": "0.39.1",
         "commit_hash": null,
         "container": null,
         "run_script": null,
         "language": "Python",
         "language_version": "3.9.18",
         "input_data": null,
         "parameters": {
            "job_type": "vr_foraging_v2"
         },
         "core_dependency": null
      },
      {
         "object_type": "Code",
         "url": "test",
         "name": "test",
         "version": "",
         "commit_hash": null,
         "container": null,
         "run_script": null,
         "language": null,
         "language_version": null,
         "input_data": null,
         "parameters": null,
         "core_dependency": null
      }
   ],
   "notes": null,
   "dependency_graph": {
      "Other": [],
      "Compression": []
   }
}
```